### PR TITLE
Show direct parent folder in backlinks

### DIFF
--- a/.github/workflows/build-with-npm.yaml
+++ b/.github/workflows/build-with-npm.yaml
@@ -1,0 +1,20 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: npm run dist
+        run: |
+          export NODE_OPTIONS=--openssl-legacy-provider
+          npm install
+          npm run dist
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: publish/joplin.plugin.ambrt.backlinksToNote.jpl

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-backlinks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "homepage": "https://discourse.joplinapp.org/t/insert-referencing-notes-backlinks-plugin/13632",
   "description": "",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ joplin.plugins.register({
 				let useManualHint = await joplin.settings.value('myBacklinksCustomSettingUseHint')
 				let ignoreListArray = await joplin.settings.value('myBacklinksCustomSettingIgnoreList');
 				while (has_more) {
-					notes = await joplin.data.get(['search'], { query: data.id, fields: ['id', 'title', 'body'], page: page });
+					notes = await joplin.data.get(['search'], { query: data.id, fields: ['id', 'title', 'body', 'parent_id'], page: page });
 					
 					for (let i = 0; i < notes.items.length; i++) {
 						let element = notes.items[i];
@@ -152,7 +152,8 @@ joplin.plugins.register({
 						//references = references + "\n" + `[${escapeTitleText(element.title)}](:/${element.id})`;
 						let inIgnoreList = ignoreListArray.includes(element.id)
 						if (!(ignore || inIgnoreList)) {
-							references = references + "\n" + `[${escapeTitleText(element.title)}](:/${element.id})`;
+							const parent = await joplin.data.get(['folders', element.parent_id], { fields: ['title'] });
+							references = references + "\n" +	`${escapeTitleText(parent.title)}/[${escapeTitleText(element.title)}](:/${element.id})`;
 							thereAreNotes = true
 						}
 					}
@@ -325,7 +326,7 @@ joplin.plugins.register({
 				let thereAreAutoBacklinks = false
 				
 				while (has_more) {
-					notes = await joplin.data.get(['search'], { query: data.id, fields: ['id', 'title', 'body'], page: page });
+					notes = await joplin.data.get(['search'], { query: data.id, fields: ['id', 'title', 'body', 'parent_id'], page: page });
 					console.log(notes)
 					let ignoreListArray = await joplin.settings.value('myBacklinksCustomSettingIgnoreList');
 					for (let i = 0; i < notes.items.length; i++) {
@@ -336,8 +337,8 @@ joplin.plugins.register({
 						//references = references + "\n" + `[${escapeTitleText(element.title)}](:/${element.id})`;
 						let inIgnoreList = ignoreListArray.includes(element.id)
 						if (!(ignore || inIgnoreList)) {
-							
-							references = references + "" + `${joplinIcon}<a href="#" onclick="webviewApi.postMessage('${contentScriptId}', {type:'openNote',noteId:'${element.id}'})">${escapeTitleText(element.title)}</a><br>`;
+							const parent = await joplin.data.get(['folders', element.parent_id], { fields: ['title'] });
+							references = references + "" + `${joplinIcon}<a href="#" onclick="webviewApi.postMessage('${contentScriptId}', {type:'openNote',noteId:'${element.id}'})">${escapeTitleText(parent.title)}/${escapeTitleText(element.title)}</a><br>`;
 							thereAreAutoBacklinks = true
 						}
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,9 +2,9 @@
 	"manifest_version": 1,
 	"id": "joplin.plugin.ambrt.backlinksToNote",
 	"app_min_version": "1.7",
-	"version": "3.0.3",
-	"name": "Automatic Backlinks to note",
+	"version": "3.0.4",
+        "name": "Automatic Backlinks to note (enhanced)",
 	"description": "Creates backlinks to opened note, also in automatic way",
-	"author": "ambrt,cyingfan",
+        "author": "ambrt,cyingfan,pmiddend",
 	"homepage_url": "https://discourse.joplinapp.org/t/insert-referencing-notes-backlinks-plugin/13632"
 }


### PR DESCRIPTION
This should fix #12. I've also added a GitHub workflow which auto-uploads an artifact containing the build package.

Example (the extra space I removed in the final version):

![image](https://github.com/user-attachments/assets/1e922068-883d-452e-96c1-91e726dbaf56)
